### PR TITLE
Replace the ChooseItem control with new GoToItem

### DIFF
--- a/src/controllers/controlpickermenu.cpp
+++ b/src/controllers/controlpickermenu.cpp
@@ -402,6 +402,10 @@ ControlPickerMenu::ControlPickerMenu(QWidget* pParent)
                        tr("Move focus to right/left pane"),
                        tr("Move focus one pane to right or left using a knob, as if pressing TAB/SHIFT+TAB keys"),
                        m_libraryStr, libraryMenu);
+    addPrefixedControl("[Library]", "GoToItem",
+                       tr("Go to the currently selected item"),
+                       tr("Choose the currently selected item and advance forward one pane if appropriate"),
+                       m_libraryStr, libraryMenu);
     addPrefixedControl("[Library]", "AutoDjAddBottom",
                        tr("Add to Auto DJ Queue (bottom)"),
                        tr("Append the selected track to the Auto DJ Queue"),

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -37,7 +37,7 @@ class LibraryControl : public QObject {
   public:
     LibraryControl(Library* pLibrary);
     virtual ~LibraryControl();
-    
+
     void bindSidebarWidget(WLibrarySidebar* pLibrarySidebar);
 
   private slots:
@@ -55,7 +55,7 @@ class LibraryControl : public QObject {
     void slotMoveFocusForward(double);
     void slotMoveFocusBackward(double);
     void slotMoveFocus(double);
-    void slotChooseItem(double v);
+    void slotGoToItem(double v);
 
     // Deprecated navigation slots
     void slotLoadSelectedTrackToGroup(QString group, bool play);
@@ -108,7 +108,7 @@ class LibraryControl : public QObject {
     std::unique_ptr<ControlObject> m_pMoveFocus;
 
     // Control to choose the currently selected item in focused widget (double click)
-    std::unique_ptr<ControlObject> m_pChooseItem;
+    std::unique_ptr<ControlObject> m_pGoToItem;
 
     // Add to Auto-Dj Cueue
     std::unique_ptr<ControlObject> m_pAutoDjAddTop;


### PR DESCRIPTION
As we discussed in https://github.com/mixxxdj/mixxx/pull/953, I've implemented a "go to" control.

It behaves slightly differently from how you suggested (it does a carriage return + tab, unless the currently focused pane is the `WTrackTableView`).

I found that it would be rather unintuitive to have the collapsing/uncollapsing together with this control (not to mention much more difficult to implement), as uncollapsing a folder is not always the appropriate action when browsing the filesystem. E.g. maybe we have `~/Music/SomeArtist` which contains both songs and folders ( `~/Music/SomeArtist/abc.mp3` and `~/Music/SomeArtist/SomeAlbum/`). When they click on the SomeArtist folder, we have no idea whether they want to "goto" SomeArtist, or they want to toggle the expanded state and show SomeAlbum in the tree.

So I think it's more intuitive to have it goto SomeArtist and use the MoveLeft / MoveRight controls to set the expanded state (most likely via a shift+right on the controller).

