### PR TITLE
 shadow position feature fix

### DIFF
--- a/res/skins/Shade/deck.xml
+++ b/res/skins/Shade/deck.xml
@@ -264,6 +264,7 @@
 										<SignalColor>#191F24</SignalColor>
 										<PlayPosColor>#00FF00</PlayPosColor>
 										<EndOfTrackColor>#EA0000</EndOfTrackColor>
+										<PlayedOverlayColor>#60000000</PlayedOverlayColor>
 										<DefaultMark>
 											<Align>bottom|right</Align>
 											<Color>#FD0564</Color>

--- a/res/skins/Shade/sampler.xml
+++ b/res/skins/Shade/sampler.xml
@@ -160,6 +160,7 @@
 									<Pos>0,0</Pos>
 									<Size>0e,35f</Size>
 									<BgColor>#8D98A3</BgColor>
+									<PlayedOverlayColor>#60000000</PlayedOverlayColor>
 									<SignalHighColor></SignalHighColor>
 									<SignalMidColor></SignalMidColor>
 									<SignalLowColor></SignalLowColor>

--- a/res/skins/Shade/skin.xml
+++ b/res/skins/Shade/skin.xml
@@ -658,6 +658,7 @@
 															<Style></Style>
 															<Group>[PreviewDeck1]</Group>
 															<Size>me,37f</Size>
+															<PlayedOverlayColor>#40FFFFFF</PlayedOverlayColor>
 															<SignalHighColor>#FFE300</SignalHighColor>
 															<SignalMidColor>#0099FF</SignalMidColor>
 															<SignalLowColor>#FF0035</SignalLowColor>


### PR DESCRIPTION
"PlayedOverlayColor" was not used, which caused NO overlay on Shade "Classic" and a "black overlay" on Shade "summer sunnset" and Shade "dark"

before:
![shade_summer_sunnset_error](https://user-images.githubusercontent.com/3403218/34492414-c3fba746-efe7-11e7-98a2-9432232caa45.png)

after:
![shade21_summersunset](https://user-images.githubusercontent.com/3403218/35193090-230c9726-fe9e-11e7-8955-075602a6cdbc.png)
![shade21_classic](https://user-images.githubusercontent.com/3403218/35193091-25ea74fe-fe9e-11e7-961e-50e1ac29ec48.png)
![shade21_dark](https://user-images.githubusercontent.com/3403218/35193092-2743aa28-fe9e-11e7-9626-cb6581645f39.png)
