### PR TITLE
ColorPaletteEditor: move Add/Remove Color to buttons

### DIFF
--- a/src/preferences/colorpaletteeditor.cpp
+++ b/src/preferences/colorpaletteeditor.cpp
@@ -24,22 +24,39 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent)
           m_pSaveAsEdit(make_parented<QLineEdit>(this)),
           m_pTableView(make_parented<QTableView>(this)),
           m_pModel(make_parented<ColorPaletteEditorModel>(m_pTableView)) {
-    QDialogButtonBox* pButtonBox = new QDialogButtonBox();
-    m_pRemoveButton = pButtonBox->addButton(
-            tr("Remove Palette"),
-            QDialogButtonBox::DestructiveRole);
-    m_pCloseButton = pButtonBox->addButton(QDialogButtonBox::Discard);
-    m_pResetButton = pButtonBox->addButton(QDialogButtonBox::Reset);
-    m_pSaveButton = pButtonBox->addButton(QDialogButtonBox::Save);
+    // Create widgets
+    QHBoxLayout* pColorButtonLayout = new QHBoxLayout();
+    m_pAddColorButton = new QPushButton(tr("Add Color"), this);
+    pColorButtonLayout->addWidget(m_pAddColorButton);
+    connect(m_pAddColorButton,
+            &QPushButton::clicked,
+            this,
+            &ColorPaletteEditor::slotAddColor);
+    m_pRemoveColorButton = new QPushButton(tr("Remove Color"), this);
+    pColorButtonLayout->addWidget(m_pRemoveColorButton);
+    connect(m_pRemoveColorButton,
+            &QPushButton::clicked,
+            this,
+            &ColorPaletteEditor::slotRemoveColor);
 
     QHBoxLayout* pNameLayout = new QHBoxLayout();
     pNameLayout->addWidget(new QLabel(tr("Name")));
     pNameLayout->addWidget(m_pSaveAsEdit, 1);
 
+    QDialogButtonBox* pPaletteButtonBox = new QDialogButtonBox();
+    m_pRemoveButton = pPaletteButtonBox->addButton(
+            tr("Remove Palette"),
+            QDialogButtonBox::DestructiveRole);
+    m_pCloseButton = pPaletteButtonBox->addButton(QDialogButtonBox::Discard);
+    m_pResetButton = pPaletteButtonBox->addButton(QDialogButtonBox::Reset);
+    m_pSaveButton = pPaletteButtonBox->addButton(QDialogButtonBox::Save);
+
+    // Add widgets to dialog
     QVBoxLayout* pLayout = new QVBoxLayout();
+    pLayout->addLayout(pColorButtonLayout);
     pLayout->addWidget(m_pTableView, 1);
     pLayout->addLayout(pNameLayout);
-    pLayout->addWidget(pButtonBox);
+    pLayout->addWidget(pPaletteButtonBox);
     setLayout(pLayout);
     setContentsMargins(0, 0, 0, 0);
 
@@ -74,10 +91,6 @@ ColorPaletteEditor::ColorPaletteEditor(QWidget* parent)
             &QTableView::doubleClicked,
             this,
             &ColorPaletteEditor::slotTableViewDoubleClicked);
-    connect(m_pTableView,
-            &QTableView::customContextMenuRequested,
-            this,
-            &ColorPaletteEditor::slotTableViewContextMenuRequested);
     connect(m_pSaveAsEdit,
             &QLineEdit::textChanged,
             this,
@@ -147,24 +160,18 @@ void ColorPaletteEditor::slotTableViewDoubleClicked(const QModelIndex& index) {
     }
 }
 
-void ColorPaletteEditor::slotTableViewContextMenuRequested(const QPoint& pos) {
-    QMenu menu(this);
+void ColorPaletteEditor::slotAddColor() {
+    m_pModel->appendRow(kDefaultPaletteColor);
+}
 
-    QAction* pAddAction = menu.addAction("Add");
-    QAction* pRemoveAction = menu.addAction("Remove");
-    QAction* pAction = menu.exec(m_pTableView->viewport()->mapToGlobal(pos));
-    if (pAction == pAddAction) {
-        m_pModel->appendRow(kDefaultPaletteColor);
-    } else if (pAction == pRemoveAction) {
-        QModelIndexList selection = m_pTableView->selectionModel()->selectedRows();
+void ColorPaletteEditor::slotRemoveColor() {
+    QModelIndexList selection = m_pTableView->selectionModel()->selectedRows();
 
-        if (selection.count() > 0) {
-            QModelIndex index = selection.at(0);
-
-            //row selected
-            int row = index.row();
-            m_pModel->removeRow(row);
-        }
+    if (selection.count() > 0) {
+        QModelIndex index = selection.at(0);
+        //row selected
+        int row = index.row();
+        m_pModel->removeRow(row);
     }
 }
 

--- a/src/preferences/colorpaletteeditor.h
+++ b/src/preferences/colorpaletteeditor.h
@@ -24,7 +24,8 @@ class ColorPaletteEditor : public QDialog {
   private slots:
     void slotUpdateButtons();
     void slotTableViewDoubleClicked(const QModelIndex& index);
-    void slotTableViewContextMenuRequested(const QPoint& pos);
+    void slotAddColor();
+    void slotRemoveColor();
     void slotPaletteNameChanged(const QString& text);
     void slotCloseButtonClicked();
     void slotSaveButtonClicked();
@@ -39,6 +40,8 @@ class ColorPaletteEditor : public QDialog {
     parented_ptr<QLineEdit> m_pSaveAsEdit;
     parented_ptr<QTableView> m_pTableView;
     parented_ptr<ColorPaletteEditorModel> m_pModel;
+    QPushButton* m_pAddColorButton;
+    QPushButton* m_pRemoveColorButton;
     QPushButton* m_pSaveButton;
     QPushButton* m_pCloseButton;
     QPushButton* m_pRemoveButton;


### PR DESCRIPTION
instead of a right click menu where they were not easily
discoverable

![image](https://user-images.githubusercontent.com/9455094/77866142-6abf3c80-71f7-11ea-819c-98cbb3cd8ef1.png)
