### PR TITLE
Metronome fix improvements

### DIFF
--- a/src/effects/backends/builtin/metronomeeffect.h
+++ b/src/effects/backends/builtin/metronomeeffect.h
@@ -9,12 +9,10 @@
 class MetronomeGroupState final : public EffectState {
   public:
     MetronomeGroupState(const mixxx::EngineParameters& engineParameters)
-            : EffectState(engineParameters),
-              m_framesSinceClickStart(0) {
-    }
+            : EffectState(engineParameters){};
     ~MetronomeGroupState() override = default;
 
-    SINT m_framesSinceClickStart;
+    std::size_t framesSinceLastClick = 0;
 };
 
 class MetronomeEffect : public EffectProcessorImpl<MetronomeGroupState> {


### PR DESCRIPTION
this is rebased on newest 2.4 so the history is messed up because mixxx would otherwise crash on startup during testing. The only two relevant commits are the last two:

* ~da5c3feb309559cdd77f16d5198db035d9620837 which looks big but is just moving stuff around.~ merged.
* df08e9a209e7a68d801e466edf1678b46da50b0c is the only with the (IMO) improvements. It tries to not mixxx abstraction levels as badly. It also reduces the nesting which makes the meaty logic easier to understand. It also adds comments to the edge cases that are currently (as well as in https://github.com/mixxxdj/mixxx/pull/13636) broken. Unfortunately it also has an issue where the click now sounds choppy but I can't figure out why. It _should_ mostly be equivalent to your solution (assuming I understood your code in the first place).

I'd be very grateful if you could take a look soon. 